### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+    - amd64
+    - ppc64le
 python:
     - 2.7
     - 3.6


### PR DESCRIPTION
Hi, have added power support ppc64le to the travis.yml, this patch would allow us to do regression testing on ppc64le using the free travis infrastructure. ansi is part of debian and Ubuntu ppc64le distributions and this helps ensure that the source tree does not regress wrt ppc64le support. Thanks!