### PR TITLE
Use typing_extensions to properly type even for 3.6/3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist
 .tox
 *.egg-info
 .DS_Store
+.idea
+.dmypy.json

--- a/ansi/colour/base.py
+++ b/ansi/colour/base.py
@@ -23,7 +23,7 @@ class Graphic(object):
             return cast(T, self.sequence + their)
         elif isinstance(their, Graphic):
             return Graphic(*(self.values + their.values))
-        raise AssertionError('Only str and Graphic objects can be added together.')
+        raise TypeError('You can only add strings or strings decorated with escape sequences together.')
 
     def __call__(self, text: str, reset: bool = True) -> str:
         result = self.sequence + text

--- a/ansi/colour/base.py
+++ b/ansi/colour/base.py
@@ -1,9 +1,11 @@
 # pylint: disable=C0103,R0903
-from typing import Union
+from typing import TypeVar, Union, cast
 
 from ansi.sequence import sequence
 
 __all__ = ['Graphic']
+
+T = TypeVar('T', str, 'Graphic')
 
 
 class Graphic(object):
@@ -15,13 +17,13 @@ class Graphic(object):
         self.values = values
         self.sequence = sequence('m', fields=-1)(*values)
 
-    def __add__(self, their: Union[str, "Graphic"]) -> Union[str, "Graphic"]:
+    def __add__(self, their: T) -> T:
         if isinstance(their, str):
-            return ''.join([str(self), their])
-        elif isinstance(their, bytes):  # type: ignore  # This is already checked by the type annotation
-            raise TypeError('You can only add strings or strings decorated with escape sequences, not bytes.')
-        else:
+            # For some reason mypy does not understand that T is string in this case
+            return cast(T, self.sequence + their)
+        elif isinstance(their, Graphic):
             return Graphic(*(self.values + their.values))
+        raise AssertionError('Only str and Graphic objects can be added together.')
 
     def __call__(self, text: str, reset: bool = True) -> str:
         result = self.sequence + text

--- a/ansi/sequence.py
+++ b/ansi/sequence.py
@@ -1,5 +1,7 @@
 from typing import Any, List, Optional, TYPE_CHECKING, Union
 
+from typing_extensions import Protocol
+
 if TYPE_CHECKING:
     from ansi.colour.base import Graphic
 
@@ -8,7 +10,7 @@ OSC = '\x1b]'
 BEL = '\a'
 
 
-class SequenceGenerator():
+class SequenceGenerator(Protocol):
     def __call__(self, *vals: Union[int, str, "Graphic"]) -> str: ...
 
 
@@ -34,7 +36,7 @@ def sequence(letter: str, fields: int = 1,
     return _sequence
 
 
-class OSCGenerator():
+class OSCGenerator(Protocol):
     def __call__(*args: str, **kwargs: Any) -> str: ...
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,5 @@ url = https://github.com/tehmaze/ansi/
 [options]
 python_requires = >=3.6
 packages = ansi, ansi.colour
+install_requires =
+    typing_extensions~=0.1

--- a/test_ansi.py
+++ b/test_ansi.py
@@ -47,3 +47,8 @@ def test_iterm() -> None:
     from ansi import iterm
     assert iterm.attention(True) == '\x1b]1337;RequestAttention=yes\x07'
     assert iterm.attention('yes') == '\x1b]1337;RequestAttention=yes\x07'
+
+
+def test_add() -> None:
+    from ansi.colour import fg
+    assert (fg.blue + fg.bold)('x') == '\x1b[34;1mx\x1b[0m'


### PR DESCRIPTION
Use typing_extensions to properly type even for 3.6/3.7