### PR TITLE
typing-extensions and tox.ini fixes

### DIFF
--- a/ansi/sequence.py
+++ b/ansi/sequence.py
@@ -1,6 +1,11 @@
+import sys
+
 from typing import Any, List, Optional, TYPE_CHECKING, Union
 
-from typing_extensions import Protocol
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from ansi.colour.base import Graphic

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ url = https://github.com/tehmaze/ansi/
 python_requires = >=3.6
 packages = ansi, ansi.colour
 install_requires =
-    typing_extensions~=0.1
+    typing_extensions>=3.6.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ url = https://github.com/tehmaze/ansi/
 python_requires = >=3.6
 packages = ansi, ansi.colour
 install_requires =
-    typing_extensions>=3.6.4
+    typing_extensions>=3.6.4; python_version < "3.8"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = update, py36, py37, py38, py39, py310, mypy-py36
+isolated_build = True
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
1. set minimal version on typing-extensions dep
2. use it only on Python < 3.8
3. fix tox.ini after pyproject.toml addition