### PR TITLE
Use correct version dependency for typing-extenstions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ ANSI Changelog
 Various ANSI escape codes, used in moving the cursor in a text console or
 rendering coloured text.
 
+0.3.5
+-----
+- [PR #23](https://github.com/tehmaze/ansi/pull/22) Use correct version of
+  `typing_extensions` module.
+
 0.3.4
 -----
 - [PR #21](https://github.com/tehmaze/ansi/pull/21) use 3rd party

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ansi
-version = 0.3.4
+version = 0.3.5
 description = ANSI cursor movement and graphics
 author = Wijnand Modderman-Lenstra
 author_email = maze@pyth0n.org
@@ -12,4 +12,4 @@ url = https://github.com/tehmaze/ansi/
 python_requires = >=3.6
 packages = ansi, ansi.colour
 install_requires =
-    typing_extensions~=0.1
+    typing_extensions>=3.7


### PR DESCRIPTION
This is starting to become embarrassing. I tried to install the latest ansi and it didn't work, because we still had a wrong version dependency for typing-extensions. This time I locally built the package and verified that it installs and requires the correct version number.

I am sorry @jquast 🤭