### PR TITLE
Include py.typed marker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ ANSI Changelog
 Various ANSI escape codes, used in moving the cursor in a text console or
 rendering coloured text.
 
+0.3.6
+-----
+- [PR #24](https://github.com/tehmaze/ansi/pull/24) Include py.typed marker
+  to enable type checking of the installed package.
+
 0.3.5
 -----
 - [PR #21](https://github.com/tehmaze/ansi/pull/21) use 3rd party

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,7 @@ python_requires = >=3.6
 packages = ansi, ansi.colour
 install_requires =
     typing_extensions>=3.6.4; python_version < "3.8"
+include_package_data = True
+
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
Getting all the build options right is complicated

Without the py.typed marker type checking doesn't work.