### PR TITLE
add license information to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ author_email = maze@pyth0n.org
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/tehmaze/ansi/
+license = MIT License
+license_files = LICENSE.md
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
This PR adds the MIT license information from the LICENSE.md file into the setup.cfg.

### Intension

It would be great if this package would provide its MIT license information to pip and therefore supports commands like: `pip show ansi` or also packages like `pip-licenses`.

### Compare before and after

```diff
  $ pip show ansi
  Name: ansi
  Version: 0.3.6
  Summary: ANSI cursor movement and graphics
  Home-page: https://github.com/tehmaze/ansi/
  Author: Wijnand Modderman-Lenstra
  Author-email: maze@pyth0n.org
- License:
+ License: MIT License
  Location: /home/<user>/.local/lib/python3.10/site-packages
  Requires:
  Required-by:
```